### PR TITLE
Rename ComplibCompositionReader to ComplibCompositionGenerator

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from rhythm import RegressionRhythm, WaitForUserRhythm
 from tower import RingingRoomTower
 from bot import Bot
 
-from row_generation import RowGenerator, ComplibCompositionReader, MethodPlaceNotationGenerator
+from row_generation import RowGenerator, ComplibCompositionGenerator, MethodPlaceNotationGenerator
 
 
 def row_generator(args):

--- a/row_generation/__init__.py
+++ b/row_generation/__init__.py
@@ -1,4 +1,4 @@
-from .complib_composition_reader import ComplibCompositionReader
+from .complib_composition_generator import ComplibCompositionGenerator
 from .dixonoids_generator import DixonoidsGenerator
 from .go_and_stop_calling_generator import GoAndStopCallingGenerator
 from .method_place_notation_generator import MethodPlaceNotationGenerator

--- a/row_generation/complib_composition_generator.py
+++ b/row_generation/complib_composition_generator.py
@@ -7,7 +7,7 @@ from .row_generator import RowGenerator
 from bell import Bell
 
 
-class ComplibCompositionReader(RowGenerator):
+class ComplibCompositionGenerator(RowGenerator):
     complib_url = "https://complib.org/composition/"
 
     def __init__(self, id: int):


### PR DESCRIPTION
So that all the RowGenerators have names '(.*)Generator'