### PR TITLE
Add ability to detect load balancing server url

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import argparse
 from rhythm import RegressionRhythm, WaitForUserRhythm
 from tower import RingingRoomTower
 from bot import Bot
+from page_parser import get_load_balancing_url
 
 from row_generation import RowGenerator, ComplibCompositionGenerator, MethodPlaceNotationGenerator
 
@@ -105,7 +106,7 @@ def main():
     # Run the program
     configure_logging()
 
-    tower = RingingRoomTower(args.id, args.url)
+    tower = RingingRoomTower(args.id, get_load_balancing_url(args.id, args.url))
     bot = Bot(tower, row_generator(args), rhythm=rhythm(args))
 
     with tower:

--- a/page_parser.py
+++ b/page_parser.py
@@ -1,0 +1,20 @@
+"""
+A module to store functions related to parsing the HTML of the Ringing Room tower pages to find
+things like the load-balanced URL of the socket-io server.
+"""
+
+import requests
+import os
+
+def get_load_balancing_url(tower_id, http_server_url):
+    """
+    Get the URL of the socket server which (since the addition of load balancing) is not the same
+    as the URL of the http server that people will put into their browser URL bars.
+    """
+
+    html = requests.get(os.path.join(http_server_url, str(tower_id), 'x')).text
+
+    string_that_starts_with_url = html[html.index("server_ip") + len('server_ip: "'):]
+    load_balancing_url = string_that_starts_with_url[:string_that_starts_with_url.index('"')]
+
+    return load_balancing_url

--- a/page_parser.py
+++ b/page_parser.py
@@ -3,8 +3,8 @@ A module to store functions related to parsing the HTML of the Ringing Room towe
 things like the load-balanced URL of the socket-io server.
 """
 
-import requests
 import os
+import requests
 
 def get_load_balancing_url(tower_id, http_server_url):
     """

--- a/page_parser.py
+++ b/page_parser.py
@@ -8,8 +8,9 @@ import requests
 
 def get_load_balancing_url(tower_id, http_server_url):
     """
-    Get the URL of the socket server which (since the addition of load balancing) is not the same
-    as the URL of the http server that people will put into their browser URL bars.
+    Get the URL of the socket server which (since the addition of load balancing) is not
+    necessarily the same as the URL of the http server that people will put into their browser URL
+    bars.
     """
 
     html = requests.get(os.path.join(http_server_url, str(tower_id), 'x')).text

--- a/page_parser.py
+++ b/page_parser.py
@@ -22,7 +22,8 @@ def get_load_balancing_url(tower_id, http_server_url):
     url = urllib.parse.urljoin(http_server_url, str(tower_id))
     html = requests.get(url).text
 
-    string_that_starts_with_url = html[html.index("server_ip") + len('server_ip: "'):]
+    url_start_index = html.index("server_ip") + len('server_ip: "')
+    string_that_starts_with_url = html[url_start_index:]
     load_balancing_url = string_that_starts_with_url[:string_that_starts_with_url.index('"')]
 
     return load_balancing_url

--- a/page_parser.py
+++ b/page_parser.py
@@ -15,6 +15,10 @@ def get_load_balancing_url(tower_id, http_server_url):
     bars.
     """
 
+    # Trying to extract the following line in the rendered html:
+    # server_ip: "{{server_ip}}"
+    # See https://github.com/lelandpaul/virtual-ringing-room/blob/
+    #     ec00927ca57ab94fa2ff6a978ffaff707ab23a57/app/templates/ringing_room.html#L46
     url = urllib.parse.urljoin(http_server_url, str(tower_id))
     html = requests.get(url).text
 

--- a/page_parser.py
+++ b/page_parser.py
@@ -3,7 +3,8 @@ A module to store functions related to parsing the HTML of the Ringing Room towe
 things like the load-balanced URL of the socket-io server.
 """
 
-import os
+import urllib
+
 import requests
 
 
@@ -14,7 +15,8 @@ def get_load_balancing_url(tower_id, http_server_url):
     bars.
     """
 
-    html = requests.get(os.path.join(http_server_url, str(tower_id), 'x')).text
+    url = urllib.parse.urljoin(http_server_url, str(tower_id))
+    html = requests.get(url).text
 
     string_that_starts_with_url = html[html.index("server_ip") + len('server_ip: "'):]
     load_balancing_url = string_that_starts_with_url[:string_that_starts_with_url.index('"')]

--- a/page_parser.py
+++ b/page_parser.py
@@ -6,6 +6,7 @@ things like the load-balanced URL of the socket-io server.
 import os
 import requests
 
+
 def get_load_balancing_url(tower_id, http_server_url):
     """
     Get the URL of the socket server which (since the addition of load balancing) is not


### PR DESCRIPTION
This unfortunately exploits what could be considered to be a bug in ringing room, which is that the the 2nd part of the URL path (e.g. `bot_training_ground` in `https://ringingroom.com/763451928/bot_training_ground`) must be present but can be set to any value.  So the bot will set this to some arbitrary string in order to get the HTML of the page that the user would see when ringing, and then does a search for `server_ip` and then finds the URL in the quotes following it.

@centreboard, could you please add `requests` to the requirements.txt (if it isn't automatically part of Python)?

Fixes #22.